### PR TITLE
feat(auth): check idToken expiry before authenticated API calls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { isTwitchExtensionPanelPath } from './features/overlay/utils/twitchExten
 import type { Achievement } from './features/achievements/api/achievementManagement.types'
 import { Toaster } from './components/ui/sonner'
 import { addUrlOpenListener, closeExternalUrl, getLaunchUrl } from './utils/browserRuntime'
+import { useTokenExpiryGuard } from './hooks/useTokenExpiryGuard'
 
 type Screen =
   | 'landing'
@@ -46,6 +47,7 @@ export function AppContent() {
   const [currentScreen, setCurrentScreen] = useState<Screen>(() =>
     isAuthenticated ? 'dashboard' : 'landing'
   )
+  useTokenExpiryGuard(currentScreen)
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [editingAchievementId, setEditingAchievementId] = useState<Achievement['id'] | null>(null)
   const [templateAchievement, setTemplateAchievement] = useState<Achievement | null>(null)

--- a/src/features/apk/hooks/useApkDownload.ts
+++ b/src/features/apk/hooks/useApkDownload.ts
@@ -1,24 +1,24 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
+import { Capacitor } from '@capacitor/core'
 import { apkClient } from '../api/apkClient'
-
-function getIdToken(): string | null {
-  try {
-    const raw = localStorage.getItem('twitch_tokens')
-    if (!raw) return null
-    return (JSON.parse(raw) as { idToken: string }).idToken ?? null
-  } catch {
-    return null
-  }
-}
+import { useAuth } from '../../../context/AuthContext'
+import { getStoredIdToken, isIdTokenExpired } from '../../../utils/auth'
 
 export function useApkDownload() {
+  const { login } = useAuth()
   const [isDownloading, setIsDownloading] = useState(false)
 
   const triggerDownload = async (errorMessages: { service: string }) => {
-    const idToken = getIdToken()
+    const idToken = getStoredIdToken()
     if (!idToken) {
       toast.error(errorMessages.service)
+      return
+    }
+    if (isIdTokenExpired(idToken)) {
+      const storage = Capacitor.isNativePlatform() ? localStorage : sessionStorage
+      storage.setItem('return_to_screen', 'dashboard')
+      await login()
       return
     }
     setIsDownloading(true)

--- a/src/features/discord/hooks/useDiscordWebhook.ts
+++ b/src/features/discord/hooks/useDiscordWebhook.ts
@@ -1,26 +1,26 @@
 import { useState } from 'react'
+import { Capacitor } from '@capacitor/core'
 import { discordWebhookClient, DiscordWebhookError } from '../api/discordWebhookClient'
 import { useChannel } from '../../../context/ChannelContext'
-
-function getIdToken(): string | null {
-  try {
-    const raw = localStorage.getItem('twitch_tokens')
-    if (!raw) return null
-    return (JSON.parse(raw) as { idToken: string }).idToken ?? null
-  } catch {
-    return null
-  }
-}
+import { useAuth } from '../../../context/AuthContext'
+import { getStoredIdToken, isIdTokenExpired } from '../../../utils/auth'
 
 export function useDiscordWebhook() {
   const { selectedChannel } = useChannel()
+  const { login } = useAuth()
   const [isSaving, setIsSaving] = useState(false)
   const [successKey, setSuccessKey] = useState<string | null>(null)
   const [errorKey, setErrorKey] = useState<string | null>(null)
 
   const register = async (webhookUrl: string | null) => {
-    const idToken = getIdToken()
+    const idToken = getStoredIdToken()
     if (!idToken || !selectedChannel) return
+    if (isIdTokenExpired(idToken)) {
+      const storage = Capacitor.isNativePlatform() ? localStorage : sessionStorage
+      storage.setItem('return_to_screen', 'discord')
+      await login()
+      return
+    }
     setIsSaving(true)
     setSuccessKey(null)
     setErrorKey(null)

--- a/src/features/settings/components/NukeConfirmationDialog.tsx
+++ b/src/features/settings/components/NukeConfirmationDialog.tsx
@@ -5,6 +5,7 @@ import { Capacitor } from '@capacitor/core'
 import { useLanguage } from '../../../context/LanguageContext'
 import { useAuth } from '../../../context/AuthContext'
 import { useNukeAccount } from '../hooks/useNukeAccount'
+import { isIdTokenExpired } from '../../../utils/auth'
 
 const COUNTDOWN_SECONDS = 5
 
@@ -66,18 +67,6 @@ const primaryButtonStyle: CSSProperties = {
   padding: '0.625rem 1rem',
 }
 
-function isIdTokenExpired(idToken: string): boolean {
-  try {
-    const payload = idToken.split('.')[1]
-    const decoded = JSON.parse(atob(payload.replaceAll('-', '+').replaceAll('_', '/'))) as {
-      exp?: number
-    }
-    if (typeof decoded.exp !== 'number') return false
-    return decoded.exp < Math.floor(Date.now() / 1000)
-  } catch {
-    return false
-  }
-}
 
 interface NukeConfirmationDialogProps {
   readonly onClose: () => void

--- a/src/hooks/useTokenExpiryGuard.ts
+++ b/src/hooks/useTokenExpiryGuard.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+import { toast } from 'sonner'
+import { Capacitor } from '@capacitor/core'
+import { useAuth } from '../context/AuthContext'
+import { useLanguage } from '../context/LanguageContext'
+import { getStoredIdToken, isIdTokenExpired } from '../utils/auth'
+
+export function useTokenExpiryGuard(currentScreen: string) {
+  const { login, isAuthenticated } = useAuth()
+  const { t } = useLanguage()
+
+  useEffect(() => {
+    if (!isAuthenticated) return
+    const idToken = getStoredIdToken()
+    if (!idToken || !isIdTokenExpired(idToken)) return
+
+    toast.warning(t('auth.session.expired'))
+    const storage = Capacitor.isNativePlatform() ? localStorage : sessionStorage
+    storage.setItem('return_to_screen', currentScreen)
+
+    const timer = setTimeout(() => {
+      void login()
+    }, 2000)
+
+    return () => clearTimeout(timer)
+  }, [currentScreen, isAuthenticated, login, t])
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -57,6 +57,7 @@ const EN_TRANSLATIONS: TranslationMap = {
   'apk.download.downloading': 'Preparing download…',
   'apk.download.error.auth': 'Authentication failed. Please sign out and sign back in.',
   'apk.download.error.service': 'Download service unavailable. Please try again later.',
+  'auth.session.expired': 'Session expired — redirecting to Twitch login…',
   'nav.discord': 'Discord Notifications',
   'discord.webhook.title': 'Discord Notifications',
   'discord.webhook.description': 'Send achievement notifications to your Discord server.',
@@ -550,6 +551,7 @@ const FR_TRANSLATION_OVERRIDES: Partial<TranslationMap> = {
   'apk.download.error.auth': 'Authentification échouée. Veuillez vous reconnecter.',
   'apk.download.error.service':
     'Service de téléchargement indisponible. Veuillez réessayer plus tard.',
+  'auth.session.expired': 'Session expirée — redirection vers Twitch…',
   'nav.discord': 'Notifications Discord',
   'discord.webhook.title': 'Notifications Discord',
   'discord.webhook.description': 'Envoyez des notifications de succès sur votre serveur Discord.',

--- a/src/tests/features/hooks/useApkDownload.test.ts
+++ b/src/tests/features/hooks/useApkDownload.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '../../utils/test-utils'
 import { useApkDownload } from '../../../features/apk/hooks/useApkDownload'
 
+vi.mock('../../../utils/browserRuntime', () => ({
+  openExternalUrl: vi.fn(),
+  closeExternalUrl: vi.fn(),
+  getLaunchUrl: vi.fn().mockResolvedValue({ url: null }),
+  addUrlOpenListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+}))
+
 vi.mock('../../../features/apk/api/apkClient', async importOriginal => {
   const actual = await importOriginal<typeof import('../../../features/apk/api/apkClient')>()
   return {
@@ -94,5 +101,24 @@ describe('useApkDownload', () => {
 
     expect(toast.error).toHaveBeenCalledWith(errorMessages.service)
     expect(apkClient.getDownloadUrl).not.toHaveBeenCalled()
+  })
+
+  it('should trigger login and set return_to_screen when idToken is expired', async () => {
+    const expiredPayload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) - 1 }))
+      .replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '')
+    localStorage.setItem('twitch_tokens', JSON.stringify({ idToken: `h.${expiredPayload}.s` }))
+
+    const { openExternalUrl } = await import('../../../utils/browserRuntime')
+
+    const { result } = renderHook(() => useApkDownload())
+
+    await act(async () => {
+      await result.current.triggerDownload(errorMessages)
+    })
+
+    expect(apkClient.getDownloadUrl).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('return_to_screen')).toBe('dashboard')
+    expect(openExternalUrl).toHaveBeenCalled()
   })
 })

--- a/src/tests/features/hooks/useDiscordWebhook.test.ts
+++ b/src/tests/features/hooks/useDiscordWebhook.test.ts
@@ -3,6 +3,13 @@ import { renderHook, act } from '../../utils/test-utils'
 import { useDiscordWebhook } from '../../../features/discord/hooks/useDiscordWebhook'
 import { DiscordWebhookError } from '../../../features/discord/api/discordWebhookClient'
 
+vi.mock('../../../utils/browserRuntime', () => ({
+  openExternalUrl: vi.fn(),
+  closeExternalUrl: vi.fn(),
+  getLaunchUrl: vi.fn().mockResolvedValue({ url: null }),
+  addUrlOpenListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+}))
+
 vi.mock('../../../features/discord/api/discordWebhookClient', async importOriginal => {
   const actual =
     await importOriginal<typeof import('../../../features/discord/api/discordWebhookClient')>()
@@ -165,6 +172,24 @@ describe('useDiscordWebhook', () => {
     expect(discordWebhookClient.register).not.toHaveBeenCalled()
     expect(result.current.successKey).toBeNull()
     expect(result.current.errorKey).toBeNull()
+  })
+
+  it('should trigger login and set return_to_screen when idToken is expired', async () => {
+    const expiredPayload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) - 1 }))
+      .replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '')
+    localStorage.setItem('twitch_tokens', JSON.stringify({ idToken: `h.${expiredPayload}.s` }))
+
+    const { openExternalUrl } = await import('../../../utils/browserRuntime')
+
+    const { result } = renderHook(() => useDiscordWebhook())
+
+    await act(async () => {
+      await result.current.register('https://discord.com/api/webhooks/test')
+    })
+
+    expect(discordWebhookClient.register).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('return_to_screen')).toBe('discord')
+    expect(openExternalUrl).toHaveBeenCalled()
   })
 
 })

--- a/src/tests/hooks/useTokenExpiryGuard.test.ts
+++ b/src/tests/hooks/useTokenExpiryGuard.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '../utils/test-utils'
+import { useTokenExpiryGuard } from '../../hooks/useTokenExpiryGuard'
+
+vi.mock('../../utils/browserRuntime', () => ({
+  openExternalUrl: vi.fn(),
+  closeExternalUrl: vi.fn(),
+  getLaunchUrl: vi.fn().mockResolvedValue({ url: null }),
+  addUrlOpenListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+}))
+
+vi.mock('sonner', () => ({ toast: { warning: vi.fn(), error: vi.fn(), success: vi.fn() } }))
+
+function makeJwt(exp: number): string {
+  const payload = btoa(JSON.stringify({ exp }))
+    .replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '')
+  return `h.${payload}.s`
+}
+
+const now = () => Math.floor(Date.now() / 1000)
+
+const authUser = {
+  userId: 'user-1',
+  username: 'streamer',
+  channel: { id: 'ch-1', name: 'MyChannel', description: '', profileImageUrl: '' },
+  channelsWhichIsMod: [],
+}
+
+describe('useTokenExpiryGuard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    localStorage.setItem('twitch_user', JSON.stringify(authUser))
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('should do nothing when the token is valid', async () => {
+    localStorage.setItem('twitch_tokens', JSON.stringify({ idToken: makeJwt(now() + 3600) }))
+    const { toast } = await import('sonner')
+
+    renderHook(() => useTokenExpiryGuard('dashboard'))
+
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
+  it('should do nothing when no token is stored', async () => {
+    const { toast } = await import('sonner')
+
+    renderHook(() => useTokenExpiryGuard('dashboard'))
+
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
+  it('should show a warning toast immediately when token is expired', async () => {
+    localStorage.setItem('twitch_tokens', JSON.stringify({ idToken: makeJwt(now() - 1) }))
+    const { toast } = await import('sonner')
+
+    renderHook(() => useTokenExpiryGuard('dashboard'))
+
+    expect(toast.warning).toHaveBeenCalledOnce()
+  })
+
+  it('should set return_to_screen to the current screen when expired', async () => {
+    localStorage.setItem('twitch_tokens', JSON.stringify({ idToken: makeJwt(now() - 1) }))
+
+    renderHook(() => useTokenExpiryGuard('discord'))
+
+    expect(sessionStorage.getItem('return_to_screen')).toBe('discord')
+  })
+
+  it('should call login after 2 seconds when expired', async () => {
+    localStorage.setItem('twitch_tokens', JSON.stringify({ idToken: makeJwt(now() - 1) }))
+    const { openExternalUrl } = await import('../../utils/browserRuntime')
+
+    renderHook(() => useTokenExpiryGuard('dashboard'))
+
+    expect(openExternalUrl).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(2000)
+    expect(openExternalUrl).toHaveBeenCalled()
+  })
+
+  it('should cancel login redirect if the component unmounts before 2 seconds', async () => {
+    localStorage.setItem('twitch_tokens', JSON.stringify({ idToken: makeJwt(now() - 1) }))
+    const { openExternalUrl } = await import('../../utils/browserRuntime')
+
+    const { unmount } = renderHook(() => useTokenExpiryGuard('dashboard'))
+    unmount()
+    vi.advanceTimersByTime(2000)
+
+    expect(openExternalUrl).not.toHaveBeenCalled()
+  })
+})

--- a/src/tests/utils/auth.test.ts
+++ b/src/tests/utils/auth.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { isIdTokenExpired, getStoredIdToken } from '../../utils/auth'
+
+function makeJwt(exp: number): string {
+  const payload = btoa(JSON.stringify({ exp }))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '')
+  return `header.${payload}.sig`
+}
+
+const now = () => Math.floor(Date.now() / 1000)
+
+describe('isIdTokenExpired', () => {
+  it('should return false for a token expiring in the future', () => {
+    expect(isIdTokenExpired(makeJwt(now() + 3600))).toBe(false)
+  })
+
+  it('should return true for an already expired token', () => {
+    expect(isIdTokenExpired(makeJwt(now() - 1))).toBe(true)
+  })
+
+  it('should return false when the token has no exp claim', () => {
+    const payload = btoa(JSON.stringify({ sub: 'user' }))
+    expect(isIdTokenExpired(`header.${payload}.sig`)).toBe(false)
+  })
+
+  it('should return false for a malformed token', () => {
+    expect(isIdTokenExpired('not-a-jwt')).toBe(false)
+  })
+})
+
+describe('getStoredIdToken', () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => localStorage.clear())
+
+  it('should return the idToken when present', () => {
+    localStorage.setItem('twitch_tokens', JSON.stringify({ idToken: 'my-id-token' }))
+    expect(getStoredIdToken()).toBe('my-id-token')
+  })
+
+  it('should return null when twitch_tokens is absent', () => {
+    expect(getStoredIdToken()).toBeNull()
+  })
+
+  it('should return null when twitch_tokens has no idToken field', () => {
+    localStorage.setItem('twitch_tokens', JSON.stringify({ accessToken: 'acc' }))
+    expect(getStoredIdToken()).toBeNull()
+  })
+
+  it('should return null when twitch_tokens is invalid JSON', () => {
+    localStorage.setItem('twitch_tokens', 'bad-json')
+    expect(getStoredIdToken()).toBeNull()
+  })
+})

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,22 @@
+export function isIdTokenExpired(idToken: string): boolean {
+  try {
+    const payload = idToken.split('.')[1]
+    const decoded = JSON.parse(atob(payload.replaceAll('-', '+').replaceAll('_', '/'))) as {
+      exp?: number
+    }
+    if (typeof decoded.exp !== 'number') return false
+    return decoded.exp < Math.floor(Date.now() / 1000)
+  } catch {
+    return false
+  }
+}
+
+export function getStoredIdToken(): string | null {
+  try {
+    const raw = localStorage.getItem('twitch_tokens')
+    if (!raw) return null
+    return (JSON.parse(raw) as { idToken: string }).idToken ?? null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Extract isIdTokenExpired + getStoredIdToken into src/utils/auth.ts (single source of truth). Both useDiscordWebhook and useApkDownload now verify the token is not expired before the call; if it is, they store return_to_screen and trigger re-auth via login(). NukeConfirmationDialog now imports from the shared util instead of its local copy.